### PR TITLE
fix: unset ContentLength in addition to deleting header

### DIFF
--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -294,6 +294,7 @@ func hackIntoNormalGrpcRequest(req *http.Request) (*http.Request, bool) {
 	// DATA frame payload lengths. https://http2.github.io/http2-spec/#malformed This effectively
 	// switches to chunked encoding which is the default for h2
 	req.Header.Del("content-length")
+	req.ContentLength = -1
 
 	return req, isTextFormat
 }


### PR DESCRIPTION
This change is the fix for the following bug in traefik: https://github.com/traefik/traefik/issues/9697

## Changes

Unset ContentLength in addition to deleting header

## Verification

Tested it with traefik (3.0.0-beta2 and 3.0.0-beta3), a grpc-java service (1.52.0) and grpc-web (1.4.2) client